### PR TITLE
Reload systemd after service/timer changes

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,0 +1,3 @@
+- name: Reload systemd
+  systemd:
+    daemon_reload: true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -13,7 +13,7 @@
           dest: "/etc/systemd/system/{{ item.key }}.service"
           owner: root
           group: root
-          mode: 0750
+          mode: 0640
       with_dict: "{{ timers }}"
       notify: Reload systemd
 
@@ -23,7 +23,7 @@
           dest: "/etc/systemd/system/{{ item.key }}.timer"
           owner: root
           group: root
-          mode: 0750
+          mode: 0640
       with_dict: "{{ timers }}"
       notify: Reload systemd
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -15,6 +15,7 @@
           group: root
           mode: 0750
       with_dict: "{{ timers }}"
+      notify: Reload systemd
 
     - name: Uploading timer file
       template:
@@ -24,6 +25,7 @@
           group: root
           mode: 0750
       with_dict: "{{ timers }}"
+      notify: Reload systemd
 
     - name: Enabling timers
       systemd:


### PR DESCRIPTION
Hey, I like your ansible role and would like to contribute something back. When changing a service file systemd complains about that service being changed on disk and simply runs the old service:

Warning: foo.service changed on disk. Run 'systemctl daemon-reload' to reload units.

A small notification to an ansible handler reloading systemd does the job :-)
