### PR TITLE
Change file modes to suppress systemd warnings

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -13,7 +13,7 @@
           dest: "{{ systemd_base_path | default('/etc/systemd/system') }}/{{ item.key }}.service"
           owner: "{{ item.value.timer_user | default('root') }}"
           group: "{{ item.value.timer_user | default('root') }}"
-          mode: 0640
+          mode: 0644
       with_dict: "{{ timers }}"
       notify: Reload systemd
 
@@ -23,7 +23,7 @@
           dest: "{{ systemd_base_path | default('/etc/systemd/system') }}/{{ item.key }}.timer"
           owner: "{{ item.value.timer_user | default('root') }}"
           group: "{{ item.value.timer_user | default('root') }}"
-          mode: 0640
+          mode: 0644
       with_dict: "{{ timers }}"
       notify: Reload systemd
 


### PR DESCRIPTION
Systemd gave me warnings, that "Configuration file ... is marked world-inaccessible." (see fully below). I fixed it by changing the file modes to `0644` based on [this thread](https://github.com/rockstor/rockstor-core/issues/1493).
I'm not sure about the importance of this change, but I would be grateful if you could take a look at it.

Log:
```
Oct 23 08:04:53 servername systemd[1]: Configuration file /etc/systemd/system/mytimer.timer is marked world-inaccessible. This has no effect as configuration data is accessible via APIs without restrictions. Proceeding anyway.
Oct 23 08:04:56 servername systemd[1]: Configuration file /etc/systemd/system/mytimer.service is marked world-inaccessible. This has no effect as configuration data is accessible via APIs without restrictions. Proceeding anyway.
```