### PR TITLE
Add pre-command option for timer

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Here is an example for my 1337 Telegram Bot. The Timer "calls" a script which se
 ```
 timers:
    1337TelegramBot:
+      timer_precommand: /bin/bash -c '! /usr/bin/systemctl is-active --quiet other-service.service'
       timer_command: /home/telegrambot/sendMessage.pl
       timer_user: telegrambot
       timer_OnCalendar: "*-*-* 13:37:00 CET"
@@ -26,6 +27,7 @@ That's all the magic.
 
 | Variable | Required |  Default value / Explanation |
 |----------|----------|------------------------------|
+| timer_precommand | no | Pre-command before command |
 | timer_command |  yes | Which command or script to execute |
 | timer_user | no | Under which users the timer_command is executed. Default: root |
 | timer_persistent | no | Takes a boolean argument. If true, the time when the service unit was last triggered is stored on disk. When the timer is activated, the service unit is triggered immediately if it would have been triggered at least once during the time when the timer was inactive. This is useful to catch up on missed runs of the service when the machine was off. Note that this setting only has an effect on timers configured with OnCalendar=. Defaults to false. [Source](https://www.freedesktop.org/software/systemd/man/systemd.timer.html) |

--- a/templates/service.j2
+++ b/templates/service.j2
@@ -7,6 +7,9 @@ Description={{ item.key }} Service
 
 [Service]
 Type=oneshot
+{% if item.value.timer_precommand is defined %}
+ExecStartPre={{ item.value.timer_precommand }} 
+{% endif %}
 ExecStart={{ item.value.timer_command }}
 {% if item.value.timer_user is defined %}
 User={{ item.value.timer_user }}


### PR DESCRIPTION
I've created a new pull request that adds a timer_precommand variable to the timer configuration file. This variable is used as a pre-command before the main command that the timer executes.

The pre-command can be used to perform any necessary checks or setup before the main command is executed. For example, you could use it to check if a required service is running or to set environment variables.

I've also updated the documentation to explain the new variable and added it to the configuration file template.