### PR TITLE
Add option WorkingDirectory to service template

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ That's all the magic.
 | timer_envfile |  no | Add environment file |
 | timer_user | no | Under which users the timer_command is executed. Default: root |
 | timer_persistent | no | Takes a boolean argument. If true, the time when the service unit was last triggered is stored on disk. When the timer is activated, the service unit is triggered immediately if it would have been triggered at least once during the time when the timer was inactive. This is useful to catch up on missed runs of the service when the machine was off. Note that this setting only has an effect on timers configured with OnCalendar=. Defaults to false. [Source](https://www.freedesktop.org/software/systemd/man/systemd.timer.html) |
+| timer_workingdir |  no | Set [WorkingDirectory=](https://www.freedesktop.org/software/systemd/man/systemd.exec.html#WorkingDirectory=) for the timer
 | timer_OnActiveSec | no | Relative time after the timer unit was last activated |
 | timer_OnBootSec | no | Relative time after the computer was booted |
 | timer_OnStartupSec | no | Relative time after systemd was started |

--- a/templates/service.j2
+++ b/templates/service.j2
@@ -8,12 +8,15 @@ Description={{ item.key }} Service
 [Service]
 Type=oneshot
 {% if item.value.timer_envfile is defined %}
-EnvironmentFile={{ item.value.timer_envfile }} 
+EnvironmentFile={{ item.value.timer_envfile }}
 {% endif %}
 {% if item.value.timer_precommand is defined %}
-ExecStartPre={{ item.value.timer_precommand }} 
+ExecStartPre={{ item.value.timer_precommand }}
 {% endif %}
 ExecStart={{ item.value.timer_command }}
 {% if item.value.timer_user is defined %}
 User={{ item.value.timer_user }}
+{% endif %}
+{% if item.value.timer_workingdir is defined %}
+WorkingDirectory={{ item.value.timer_workingdir }}
 {% endif %}


### PR DESCRIPTION
This new pull request adds the option to set the working directory of the timer. The `timer_workingdir` variable is used to configure the systemd [WorkingDirectory=](https://www.freedesktop.org/software/systemd/man/systemd.exec.html#WorkingDirectory=) in the timer configuration file. 

Also removed some trailing whitespace from the service template.

@vlcty Feel free to request any changes and thanks for your work! 👍 