### PR TITLE
Avoid setting User attribute in 'user' scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ timers:
 
 That's all the magic.
 
-### Existing variables
+### Existing variables per timer
 
 | Variable | Required |  Default value / Explanation |
 |----------|----------|------------------------------|
@@ -57,6 +57,24 @@ The timer unit will be triggered 20 seconds after systemd was started and then e
 More about timers: https://www.freedesktop.org/software/systemd/man/systemd.timer.html
 
 More about timespans: https://www.freedesktop.org/software/systemd/man/systemd.time.html
+
+### Existing variables globally, for the role
+| Variable | Required | Default value / Explanation                                                                                                                            |
+|----------|----------|--------------------------------------------------------------------------------------------------------------------------------------------------------|
+| systemd_scope | no       | Create system or user units. Default: `system`.                                                                                                        |
+| systemd_base_path | no    | Where to generate the systemd unit files. Set this to e.g. `~/.config/systemd/user` when using *systemd_scope*=`user`. Default: `/etc/systemd/system`. |
+
+You can create user timers for non-root services in combination with `become_user: '{{ my_user }}'`. Example:
+```
+systemd_base_path: ~/.config/systemd/user
+systemd_scope: user
+timers:
+  timer-one:
+    timer_command: ...
+    timer_OnCalendar: ...
+    timer_user: '{{ my_user }}'
+  ...
+```
 
 ## Working with shell redirection
 

--- a/templates/service.j2
+++ b/templates/service.j2
@@ -14,7 +14,7 @@ EnvironmentFile={{ item.value.timer_envfile }}
 ExecStartPre={{ item.value.timer_precommand }}
 {% endif %}
 ExecStart={{ item.value.timer_command }}
-{% if item.value.timer_user is defined %}
+{% if item.value.timer_user is defined and (systemd_scope is not defined or systemd_scope != 'user') %}
 User={{ item.value.timer_user }}
 {% endif %}
 {% if item.value.timer_workingdir is defined %}


### PR DESCRIPTION
Setting `User=...` in a unit in 'user' systemd scope has some unwanted effects.

I ran the role as follows, using `become_user`, `systemd_scope: user` and a user-specific `systemd_base_path`.

```
    - name: Enable timers
      include_role:
        name: systemd_timer
      args:
        apply:
          become_user: '{{ container_run_as_user }}'
      vars:
        systemd_base_path: ~/.config/systemd/user
        systemd_scope: user
        timers:
           ...
```

This works well until systemd tries to run these units and created error such as _Failed at step GROUP spawning podman: Operation not permitted_.

Avoiding the User property in unit files in this case solves the problem.

