### PR TITLE
[FIX] systemd: state

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -30,7 +30,7 @@
     - name: Enabling timers
       systemd:
           name: "{{ item.key }}.timer"
-          state: restarted
+          state: started
           enabled: true
           masked: false
           daemon_reload: true


### PR DESCRIPTION
restarted state with systemd works differently on newer systemd versions (e.g. in Ubuntu 24.04). It can cause service to run immediately after restart, when expectation is to run it on schedule.